### PR TITLE
feat: add endpoint for average income by gender

### DIFF
--- a/src/main/java/com/iara/genero/generostats/controller/StatisticsController.java
+++ b/src/main/java/com/iara/genero/generostats/controller/StatisticsController.java
@@ -1,0 +1,30 @@
+package com.iara.genero.generostats.controller;
+
+import com.iara.genero.generostats.service.StatisticsService;
+import com.iara.genero.generostats.dto.GenderIncomeStats;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller for handling statistical queries related to EPH data.
+ */
+@RestController
+@RequestMapping("/api/eph/stats")
+public class StatisticsController {
+
+    private final StatisticsService statisticsService;
+
+    public StatisticsController(StatisticsService statisticsService) {
+        this.statisticsService = statisticsService;
+    }
+
+    /**
+     * Returns the average income by gender and the gap percentage.
+     * @return GenderIncomeStats object containing average incomes and gap percentage
+     */
+    @GetMapping("/average-income")
+    public GenderIncomeStats getAverageIncome() {
+        return statisticsService.getAverageIncomeByGender();
+    }
+}

--- a/src/main/java/com/iara/genero/generostats/dto/GenderIncomeStats.java
+++ b/src/main/java/com/iara/genero/generostats/dto/GenderIncomeStats.java
@@ -1,0 +1,12 @@
+package com.iara.genero.generostats.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class GenderIncomeStats {
+    private double maleAverage;
+    private double femaleAverage;
+    private double gapPercentage;
+}

--- a/src/main/java/com/iara/genero/generostats/model/RawEPHRecord.java
+++ b/src/main/java/com/iara/genero/generostats/model/RawEPHRecord.java
@@ -3,12 +3,16 @@ package com.iara.genero.generostats.model;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+/**
+ * Domain class representing a row from the EPH data file.
+ * Contains household-level survey information used for gender-based statistics.
+ */
 @Data
 @AllArgsConstructor
 public class RawEPHRecord {
-    private int year;
-    private int quarter;
+    private Integer year;
+    private Integer quarter;
     private String gender;
-    private double income;
+    private Double income;
     private String location;
 }

--- a/src/main/java/com/iara/genero/generostats/service/StatisticsService.java
+++ b/src/main/java/com/iara/genero/generostats/service/StatisticsService.java
@@ -1,0 +1,82 @@
+package com.iara.genero.generostats.service;
+
+import com.iara.genero.generostats.dto.GenderIncomeStats;
+import com.iara.genero.generostats.model.RawEPHRecord;
+import com.iara.genero.generostats.util.EphDataHolder;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service layer containing business logic for statistical operations on EPH data.
+ * Provides methods to compute income statistics segmented by gender and other criteria.
+ */
+@Service
+public class StatisticsService {
+
+    private final EphDataHolder ephDataHolder;
+
+    public StatisticsService(EphDataHolder ephDataHolder) {
+        this.ephDataHolder = ephDataHolder;
+    }
+
+    /**
+     * Calculates the average income by gender and the income gap percentage.
+     * @return GenderIncomeStats object containing average incomes and gap percentage
+     */
+    public GenderIncomeStats getAverageIncomeByGender () {
+        List<RawEPHRecord> records = ephDataHolder.getRecords();
+        List<Double> femaleIncomes = records.stream()
+                .filter(record -> record.getGender().equalsIgnoreCase("Female")
+                        && record.getIncome() != null)
+                .map(RawEPHRecord::getIncome)
+                .toList();
+
+        List<Double> maleIncomes = records.stream()
+                .filter(record -> record.getGender().equalsIgnoreCase("Male")
+                        && record.getIncome() != null)
+                .map(RawEPHRecord::getIncome)
+                .toList();
+
+        double femaleAvg = Math.round(average(femaleIncomes) * 100.0) / 100.0;
+        double maleAvg = Math.round(average(maleIncomes) * 100.0) / 100.0;
+        double gapPercentage = maleAvg != 0 ? ((maleAvg - femaleAvg) / maleAvg) * 100 : 0;
+        gapPercentage = BigDecimal.valueOf(Math.abs(gapPercentage))
+                .setScale(2, RoundingMode.HALF_UP)
+                .doubleValue();
+        return new GenderIncomeStats(femaleAvg, maleAvg, gapPercentage);
+    }
+
+    /**
+     * Counts the number of households by gender of the head of household.
+     * @return A map with gender as key and household count as value.
+     */
+    public Map<String, Long> getHouseholdCountByGender () {
+        // TODO: Implement this method to count households
+        return Map.of();
+    }
+
+    /**
+     * Calculetes the overall income gap percentage between genders.
+     * @return income gap as a percentage.
+     */
+    public double getIncomeGapPercentage () {
+        // TODO: Implement this method to calculate income gap percentage
+        return 0;
+    }
+
+    /**
+     * Utility method to calculate the average of a list of Double values.
+     * @param values the list of Double values to average
+     * @return the average value, or 0.0 if the list is empty
+     */
+    private Double average(List<Double> values) {
+        return values.stream()
+                .mapToDouble(Double::doubleValue)
+                .average()
+                .orElse(0.0);
+    }
+}

--- a/src/main/java/com/iara/genero/generostats/util/EphDataHolder.java
+++ b/src/main/java/com/iara/genero/generostats/util/EphDataHolder.java
@@ -1,0 +1,31 @@
+package com.iara.genero.generostats.util;
+
+import com.iara.genero.generostats.model.RawEPHRecord;
+import com.iara.genero.generostats.service.EphFileReaderService;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * Loads EPH household data once and provides it to services that need access.
+ */
+@Component
+public class EphDataHolder {
+
+    private final List<RawEPHRecord> records;
+
+    public EphDataHolder(EphFileReaderService readerService) {
+        File file = new File("src/main/resources/data/eph/hogar_T422.txt");
+        this.records = readerService.readRecords(file);
+    }
+
+    /**
+     * Returns the preloaded EPH records.
+     *
+     * @return list of RawEPHRecord entries
+     */
+    public List<RawEPHRecord> getRecords() {
+        return records;
+    }
+}


### PR DESCRIPTION
### Summary
This pull request adds a new REST API endpoint to calculate and return the average income by gender and the income gap percentage.

### Changes
- Added getAverageIncomeByGender() method in StatisticsService
- Created DTO GenderIncomeStats to hold API response
- Integrated with EphDataHolder for efficient data loading

### New Endpoint
GET /api/eph/stats/average-income